### PR TITLE
change signalr v from ^5.0.8 to ^7.0.11

### DIFF
--- a/packages/sdk-events/package.json
+++ b/packages/sdk-events/package.json
@@ -78,7 +78,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@microsoft/signalr": "^5.0.8",
+    "@microsoft/signalr": "^7.0.11",
     "@tzkt/sdk-api": "^2.2.0",
     "zen-observable": "^0.8.15"
   },


### PR DESCRIPTION
- Bug fix: signalR didn't work on server side

- signalR doesn't work on server side ![image](https://github.com/tzkt/api-sdk-ts/assets/69320878/5317ca68-221a-4f8d-884c-0450adbd215a)

- signalr must work on server side